### PR TITLE
Fix response type.

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -6,7 +6,7 @@ use Closure;
 use RuntimeException;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Panther\Client as PantherClient;
 
 class Middleware


### PR DESCRIPTION
There was a similar [issue](https://github.com/spatie/laravel-pjax/issues/30) with spatie/laravel-pjax.

Currently Illuminate\Http\Response as a return type causes an [exception](https://sentry.io/share/issue/1c0a4de502a043f1b4dbffd9dc90f6e1/) on JSON response:
```
Return value of Depictr\Middleware::handle() must be an instance of Illuminate\Http\Response, instance of Illuminate\Http\JsonResponse returned
```