### PR TITLE
Add ability to whitelist certain URLs so Laravel processes normally

### DIFF
--- a/config/depictr.php
+++ b/config/depictr.php
@@ -56,4 +56,16 @@ return [
         */
         'ia_archiver',          // Alexa
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | White List
+    |--------------------------------------------------------------------------
+    |
+    | URLs that should NOT be processed by depictr. Useful for plain text files
+    | like sitemap.txt where Panther will wrap it in a stripped down HTML file.
+    | Uses $request->is() so using `*` for wildcard is permitted.
+    |
+    */
+    'whitelist' => [],
 ];

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -51,7 +51,8 @@ class Middleware
             || app()->environment('testing'))
             && $this->comesFromCrawler($request)
             && $request->isMethod('GET')
-            && ! $request->header('X-Inertia');
+            && ! $request->header('X-Inertia')
+            && ! $this->whiteListed($request);
     }
 
     /**
@@ -90,5 +91,18 @@ class Middleware
             'content' => $pageSource,
             'code' => 200,
         ];
+    }
+
+    /**
+     * Returns whether not the request is a whitelisted URL. Uses
+     * $request->is() so `*` as wildcard is permitted.
+     *
+     * @param      \Illuminate\Http\Request  $request  The request
+     *
+     * @return     boolean
+     */
+    private function whiteListed(Request $request): bool
+    {
+        return $request->is(config('depictr.whitelist', []));
     }
 }


### PR DESCRIPTION
Needed this due to Panther seemingly returning documents that are text/plain e.g. `sitemaps.txt` as an html file.